### PR TITLE
ShARC: add modulefiles for Intel Parallel Studio Composer Edition 2017 products

### DIFF
--- a/compilers/intel/2017/sheffield/sharc/compilers_modulefile
+++ b/compilers/intel/2017/sheffield/sharc/compilers_modulefile
@@ -1,0 +1,119 @@
+#%Module1.0#####################################################################
+##
+## Intel compilers 2017 module file
+## 
+################################################################################
+
+## Module file logging
+#source /usr/local/etc/module_logging.tcl
+##
+
+proc ModulesHelp { } {
+        global version
+
+        puts stderr "   Makes `Intel C++ and Fortran compilers plus debugger version $version' available for use"
+}
+
+module-whatis   "Makes Intel C++ and Fortran compilers (ifort and icc) and debugger available"
+
+conflict dev/intel/2015/binary
+
+# module variables
+#
+set     version 2017
+set     intelroot    /usr/local/packages/dev/intel/$version/binary
+ 
+# load java  ( needed with debugging etc. ) 
+module load apps/java
+
+# Compiler variables determined using
+# env2 -from bash -to modulecmd "/usr/local/packages/dev/intel/2017/binary/bin/compilervars.sh intel64" | sed -e "s#/usr/local/packages/dev/intel/2017/binary#\$intelroot#g" -e 's/[{}]//g'
+# 
+prepend-path MIC_LD_LIBRARY_PATH $intelroot/compilers_and_libraries_2017.0.098/linux/tbb/lib/mic;
+prepend-path MIC_LD_LIBRARY_PATH $intelroot/compilers_and_libraries_2017.0.098/linux/mkl/lib/mic;
+prepend-path MIC_LD_LIBRARY_PATH $intelroot/compilers_and_libraries_2017.0.098/linux/compiler/lib/mic;
+prepend-path MIC_LD_LIBRARY_PATH $intelroot/compilers_and_libraries_2017.0.098/linux/ipp/lib/mic;
+prepend-path MIC_LD_LIBRARY_PATH $intelroot/compilers_and_libraries_2017.0.098/linux/compiler/lib/mic;
+prepend-path MIC_LD_LIBRARY_PATH $intelroot/compilers_and_libraries_2017.0.098/linux/mpi/mic/lib;
+prepend-path PATH $intelroot/debugger_2017/gdb/intel64_mic/bin;
+prepend-path PATH $intelroot/compilers_and_libraries_2017.0.098/linux/mpi/intel64/bin;
+prepend-path PATH $intelroot/compilers_and_libraries_2017.0.098/linux/bin/intel64;
+prepend-path MANPATH $intelroot/documentation_2017/en/debugger//gdb-igfx/man/;
+prepend-path MANPATH $intelroot/documentation_2017/en/debugger//gdb-mic/man/;
+prepend-path MANPATH $intelroot/documentation_2017/en/debugger//gdb-ia/man/;
+prepend-path MANPATH $intelroot/compilers_and_libraries_2017.0.098/linux/mpi/man;
+prepend-path MANPATH $intelroot/man/common;
+prepend-path LIBRARY_PATH $intelroot/compilers_and_libraries_2017.0.098/linux/daal/lib/intel64_lin;
+prepend-path LIBRARY_PATH $intelroot/compilers_and_libraries_2017.0.098/linux/tbb/lib/intel64/gcc4.7;
+prepend-path LIBRARY_PATH $intelroot/compilers_and_libraries_2017.0.098/linux/mkl/lib/intel64;
+prepend-path LIBRARY_PATH $intelroot/compilers_and_libraries_2017.0.098/linux/compiler/lib/intel64;
+prepend-path LIBRARY_PATH $intelroot/compilers_and_libraries_2017.0.098/linux/ipp/lib/intel64;
+prepend-path MIC_LIBRARY_PATH $intelroot/compilers_and_libraries_2017.0.098/linux/tbb/lib/mic;
+prepend-path MIC_LIBRARY_PATH $intelroot/compilers_and_libraries_2017.0.098/linux/mkl/lib/mic;
+prepend-path MIC_LIBRARY_PATH $intelroot/compilers_and_libraries_2017.0.098/linux/compiler/lib/mic;
+prepend-path MIC_LIBRARY_PATH $intelroot/compilers_and_libraries_2017.0.098/linux/compiler/lib/mic;
+prepend-path MIC_LIBRARY_PATH $intelroot/compilers_and_libraries_2017.0.098/linux/mpi/mic/lib;
+prepend-path CLASSPATH $intelroot/compilers_and_libraries_2017.0.098/linux/daal/lib/daal.jar;
+prepend-path CLASSPATH $intelroot/compilers_and_libraries_2017.0.098/linux/mpi/intel64/lib/mpi.jar;
+append-path INTEL_LICENSE_FILE $intelroot/compilers_and_libraries_2017.0.098/linux/licenses;
+append-path INTEL_LICENSE_FILE /opt/intel/licenses;
+append-path INTEL_LICENSE_FILE /home/sa_cs1wf/intel/licenses;
+prepend-path CPATH $intelroot/compilers_and_libraries_2017.0.098/linux/daal/include;
+prepend-path CPATH $intelroot/compilers_and_libraries_2017.0.098/linux/tbb/include;
+prepend-path CPATH $intelroot/compilers_and_libraries_2017.0.098/linux/mkl/include;
+prepend-path CPATH $intelroot/compilers_and_libraries_2017.0.098/linux/ipp/include;
+prepend-path LD_LIBRARY_PATH $intelroot/compilers_and_libraries_2017.0.098/linux/daal/lib/intel64_lin;
+prepend-path LD_LIBRARY_PATH $intelroot/debugger_2017/libipt/intel64/lib;
+prepend-path LD_LIBRARY_PATH $intelroot/debugger_2017/iga/lib;
+prepend-path LD_LIBRARY_PATH $intelroot/compilers_and_libraries_2017.0.098/linux/tbb/lib/intel64/gcc4.7;
+prepend-path LD_LIBRARY_PATH $intelroot/compilers_and_libraries_2017.0.098/linux/mkl/lib/intel64;
+prepend-path LD_LIBRARY_PATH $intelroot/compilers_and_libraries_2017.0.098/linux/compiler/lib/intel64;
+prepend-path LD_LIBRARY_PATH $intelroot/compilers_and_libraries_2017.0.098/linux/ipp/lib/intel64;
+prepend-path LD_LIBRARY_PATH $intelroot/compilers_and_libraries_2017.0.098/linux/mpi/mic/lib;
+prepend-path LD_LIBRARY_PATH $intelroot/compilers_and_libraries_2017.0.098/linux/mpi/intel64/lib;
+prepend-path LD_LIBRARY_PATH $intelroot/compilers_and_libraries_2017.0.098/linux/compiler/lib/intel64_lin;
+prepend-path LD_LIBRARY_PATH $intelroot/compilers_and_libraries_2017.0.098/linux/compiler/lib/intel64;
+prepend-path INFOPATH $intelroot/documentation_2017/en/debugger//gdb-igfx/info/;
+prepend-path INFOPATH $intelroot/documentation_2017/en/debugger//gdb-mic/info/;
+prepend-path INFOPATH $intelroot/documentation_2017/en/debugger//gdb-ia/info/;
+prepend-path NLSPATH $intelroot/debugger_2017/gdb/intel64/share/locale/%l_%t/%N;
+prepend-path NLSPATH $intelroot/debugger_2017/gdb/intel64_mic/share/locale/%l_%t/%N;
+prepend-path NLSPATH $intelroot/compilers_and_libraries_2017.0.098/linux/mkl/lib/intel64/locale/%l_%t/%N;
+prepend-path NLSPATH $intelroot/compilers_and_libraries_2017.0.098/linux/compiler/lib/intel64/locale/%l_%t/%N;
+
+# Debugger variables determined using
+# env2 -from bash -to modulecmd "/usr/local/packages/dev/intel/2017/binary/debugger_2017/bin/debuggervars.sh intel64" | sed -e "s#/usr/local/packages/dev/intel/2017/binary#\$intelroot#g" -e 's/[{}]//g'
+#
+setenv GDB_CROSS {/usr/local/packages/dev/intel/2017/binary/debugger_2017/gdb/intel64_mic/bin/gdb-mic};
+setenv INTEL_PYTHONHOME {/usr/local/packages/dev/intel/2017/binary/debugger_2017/python/intel64/};
+prepend-path PATH {/usr/local/packages/dev/intel/2017/binary/debugger_2017/gdb/intel64_mic/bin};
+prepend-path LD_LIBRARY_PATH {/usr/local/packages/dev/intel/2017/binary/debugger_2017/libipt/intel64/lib};
+prepend-path LD_LIBRARY_PATH {/usr/local/packages/dev/intel/2017/binary/debugger_2017/iga/lib};
+prepend-path MANPATH {/usr/local/packages/dev/intel/2017/binary/documentation_2017/en/debugger//gdb-igfx/man/};
+prepend-path MANPATH {/usr/local/packages/dev/intel/2017/binary/documentation_2017/en/debugger//gdb-mic/man/};
+prepend-path MANPATH {/usr/local/packages/dev/intel/2017/binary/documentation_2017/en/debugger//gdb-ia/man/};
+setenv MPM_LAUNCHER {/usr/local/packages/dev/intel/2017/binary/debugger_2017/mpm/mic/bin/start_mpm.sh};
+append-path INFOPATH {/usr/local/packages/dev/intel/2017/binary/documentation_2017/en/debugger//gdb-ia/info/};
+append-path INFOPATH {/usr/local/packages/dev/intel/2017/binary/documentation_2017/en/debugger//gdb-mic/info/};
+append-path INFOPATH {/usr/local/packages/dev/intel/2017/binary/documentation_2017/en/debugger//gdb-igfx/info/};
+setenv GDBSERVER_MIC {/usr/local/packages/dev/intel/2017/binary/debugger_2017/gdb/targets/mic/bin/gdbserver};
+prepend-path NLSPATH {/usr/local/packages/dev/intel/2017/binary/debugger_2017/gdb/intel64/share/locale/%l_%t/%N};
+prepend-path NLSPATH {/usr/local/packages/dev/intel/2017/binary/debugger_2017/gdb/intel64_mic/share/locale/%l_%t/%N};
+
+# Shorthand variables for compilers
+
+set     cc              icc
+set     cxx             icpc
+set     f77             ifort
+set     f90             ifort
+set     f95             ifort
+set     fc              ifort
+setenv          CC              $cc
+setenv          CXX             $cxx
+setenv          F77             $f77
+setenv          FC              $fc
+setenv          F90             $f90
+setenv          F95             $f95
+
+# License file (points at license server)
+setenv INTEL_LICENSE_FILE /usr/local/packages/dev/intel/license.lic

--- a/compilers/intel/2017/sheffield/sharc/daal-modulefile
+++ b/compilers/intel/2017/sheffield/sharc/daal-modulefile
@@ -1,0 +1,34 @@
+#%Module1.0#####################################################################
+##
+## Intel Data Analytics Accelleration Library (DAAL) 2017 module file
+## 
+################################################################################
+
+## Module file logging
+#source /usr/local/etc/module_logging.tcl
+##
+
+proc ModulesHelp { } {
+        global version
+
+        puts stderr "   Makes the `Intel Data Analytics Accelleration Library (DAAL) $version' available for use"
+}
+
+module-whatis   "Makes the `Intel Data Analytics Accelleration Library (DAAL) $version' available for use"
+
+# module variables
+#
+set     version      2017
+set     daalroot    /usr/local/packages/libs/intel-daal/$version/binary
+
+# Variables determined using
+# env2 -from bash -to modulecmd "/usr/local/packages/dev/intel/2017/binary/compilers_and_libraries_2017.0.098/linux/daal/bin/daalvars.sh intel64" | sed -e "s#/usr/local/packages/dev/intel/2017/binary#\$daalroot#g" -e 's/[{}]//g'
+# 
+prepend-path LIBRARY_PATH $daalroot/compilers_and_libraries_2017.0.098/linux/daal/lib/intel64_lin;
+prepend-path CLASSPATH $daalroot/compilers_and_libraries_2017.0.098/linux/daal/lib/daal.jar;
+prepend-path CPATH $daalroot/compilers_and_libraries_2017.0.098/linux/daal/include;
+prepend-path LD_LIBRARY_PATH $daalroot/compilers_and_libraries_2017.0.098/linux/daal/lib/intel64_lin;
+
+
+# License file (points at license server)
+setenv INTEL_LICENSE_FILE /usr/local/packages/dev/intel/license.lic

--- a/compilers/intel/2017/sheffield/sharc/ipp-modulefile
+++ b/compilers/intel/2017/sheffield/sharc/ipp-modulefile
@@ -1,0 +1,35 @@
+#%Module1.0#####################################################################
+##
+## Intel Integrated Performance Primitives (IPP) 2017 module file
+## 
+################################################################################
+
+## Module file logging
+#source /usr/local/etc/module_logging.tcl
+##
+
+proc ModulesHelp { } {
+        global version
+
+        puts stderr "   Makes the `Intel Integrated Performance Primitives (IPP) $version' available for use"
+}
+
+module-whatis   "Makes the `Intel Integrated Performance Primitives (IPP)' available for use"
+
+# module variables
+#
+set     version      2017
+set     ipproot    /usr/local/packages/libs/intel-daal/$version/binary
+
+# Variables determined using
+# env2 -from bash -to modulecmd "/usr/local/packages/dev/intel/2017/binary/compilers_and_libraries_2017.0.098/linux/ipp/bin/ippvars.sh intel64" | sed -e "s#/usr/local/packages/dev/intel/2017/binary#\$ipproot#g" -e 's/[{}]//g'
+# 
+prepend-path MIC_LD_LIBRARY_PATH $ipproot/compilers_and_libraries_2017.0.098/linux/ipp/lib/mic;
+prepend-path LIBRARY_PATH $ipproot/compilers_and_libraries_2017.0.098/linux/ipp/lib/intel64;
+setenv IPPROOT $ipproot/compilers_and_libraries_2017.0.098/linux/ipp;
+prepend-path CPATH $ipproot/compilers_and_libraries_2017.0.098/linux/ipp/include;
+prepend-path LD_LIBRARY_PATH $ipproot/compilers_and_libraries_2017.0.098/linux/ipp/lib/intel64;
+
+
+# License file (points at license server)
+setenv INTEL_LICENSE_FILE /usr/local/packages/dev/intel/license.lic

--- a/compilers/intel/2017/sheffield/sharc/mkl-modulefile
+++ b/compilers/intel/2017/sheffield/sharc/mkl-modulefile
@@ -1,0 +1,40 @@
+#%Module1.0#####################################################################
+##
+## Intel Math Kernel Library (MKL) 2017 module file
+## 
+################################################################################
+
+## Module file logging
+#source /usr/local/etc/module_logging.tcl
+##
+
+proc ModulesHelp { } {
+        global version
+
+        puts stderr "   Makes the `Intel Math Kernel Library (MLK) $version' available for use"
+}
+
+module-whatis   "Makes the `Intel Math Kernel Library (MLK) $version' available for use"
+
+# module variables
+#
+set     version      2017
+set     mklroot    /usr/local/packages/libs/intel-mkl/$version/binary
+
+# Variables determined using
+# env2 -from bash -to modulecmd "/usr/local/packages/dev/intel/2017/binary/compilers_and_libraries_2017.0.098/linux/mkl/bin/mklvars.sh intel64" | sed -e "s#/usr/local/packages/dev/intel/2017/binary#\$mklroot#g" -e 's/[{}]//g'
+# 
+prepend-path MIC_LD_LIBRARY_PATH $mklroot/compilers_and_libraries_2017.0.098/linux/mkl/lib/mic;
+prepend-path MIC_LD_LIBRARY_PATH $mklroot/compilers_and_libraries_2017.0.098/linux/compiler/lib/mic;
+prepend-path LIBRARY_PATH $mklroot/compilers_and_libraries_2017.0.098/linux/mkl/lib/intel64;
+prepend-path LIBRARY_PATH $mklroot/compilers_and_libraries_2017.0.098/linux/compiler/lib/intel64;
+prepend-path MIC_LIBRARY_PATH $mklroot/compilers_and_libraries_2017.0.098/linux/mkl/lib/mic;
+prepend-path MIC_LIBRARY_PATH $mklroot/compilers_and_libraries_2017.0.098/linux/compiler/lib/mic;
+prepend-path CPATH $mklroot/compilers_and_libraries_2017.0.098/linux/mkl/include;
+prepend-path LD_LIBRARY_PATH $mklroot/compilers_and_libraries_2017.0.098/linux/mkl/lib/intel64;
+prepend-path LD_LIBRARY_PATH $mklroot/compilers_and_libraries_2017.0.098/linux/compiler/lib/intel64;
+prepend-path NLSPATH $mklroot/compilers_and_libraries_2017.0.098/linux/mkl/lib/intel64/locale/%l_%t/%N;
+
+
+# License file (points at license server)
+setenv INTEL_LICENSE_FILE /usr/local/packages/dev/intel/license.lic

--- a/compilers/intel/2017/sheffield/sharc/tbb-modulefile
+++ b/compilers/intel/2017/sheffield/sharc/tbb-modulefile
@@ -1,0 +1,36 @@
+#%Module1.0#####################################################################
+##
+## Intel Threading Building Blocks (TBB) 2017 module file
+## 
+################################################################################
+
+## Module file logging
+#source /usr/local/etc/module_logging.tcl
+##
+
+proc ModulesHelp { } {
+        global version
+
+        puts stderr "   Makes `Intel Threading Building Blocks (TBB) $version' available for use"
+}
+
+module-whatis   "Makes `Intel Threading Building Blocks (TBB)' available for use"
+
+# module variables
+#
+set     version      2017
+set     tbbroot    /usr/local/packages/libs/intel-tbb/$version/binary
+
+# Variables determined using
+# env2 -from bash -to modulecmd "/usr/local/packages/dev/intel/2017/binary/compilers_and_libraries_2017.0.098/linux/tbb/bin/tbbvars.sh intel64" | sed -e "s#/usr/local/packages/dev/intel/2017/binary#\$tbbroot#g" -e 's/[{}]//g'
+# 
+prepend-path MIC_LD_LIBRARY_PATH $tbbroot/compilers_and_libraries_2017.0.098/linux/tbb/lib/mic;
+prepend-path LIBRARY_PATH $tbbroot/compilers_and_libraries_2017.0.098/linux/tbb/lib/intel64/gcc4.7;
+prepend-path MIC_LIBRARY_PATH $tbbroot/compilers_and_libraries_2017.0.098/linux/tbb/lib/mic;
+prepend-path CPATH $tbbroot/compilers_and_libraries_2017.0.098/linux/tbb/include;
+prepend-path LD_LIBRARY_PATH $tbbroot/compilers_and_libraries_2017.0.098/linux/tbb/lib/intel64/gcc4.7;
+setenv TBBROOT $tbbroot/compilers_and_libraries_2017.0.098/linux/tbb;
+
+
+# License file (points at license server)
+setenv INTEL_LICENSE_FILE /usr/local/packages/dev/intel/license.lic


### PR DESCRIPTION
- Compilers
- Data Analytics Acceleration Library (DAAL)
- Integrated Performance Primitives (IPP)
- Math Kernel Library (MKL) 
- Threading Building Blocks (TBB)

Update install script so also installs modulefiles.
