### PR TITLE
Update ShARC OpenMPI+gcc install scripts modulefiles

### DIFF
--- a/mpi/openmpi/1.10.4/sheffield/sharc/gcc-6.2
+++ b/mpi/openmpi/1.10.4/sheffield/sharc/gcc-6.2
@@ -23,7 +23,7 @@ module-whatis   "loads the necessary `openmpi-$openmpiversion' library paths"
 #setenv OMPI_MCA_btl_tcp_if_include eth0
 #setenv OMPI_MCA_btl tcp,self
 
-module load dev/$compiler/$compiler_version
+module load dev/$compiler/$compilerversion
 
 setenv MPI_HOME $openmpiroot
 

--- a/mpi/openmpi/1.10.4/sheffield/sharc/gcc-6.2
+++ b/mpi/openmpi/1.10.4/sheffield/sharc/gcc-6.2
@@ -23,6 +23,8 @@ module-whatis   "loads the necessary `openmpi-$openmpiversion' library paths"
 #setenv OMPI_MCA_btl_tcp_if_include eth0
 #setenv OMPI_MCA_btl tcp,self
 
+module load dev/$compiler/$compiler_version
+
 setenv MPI_HOME $openmpiroot
 
 prepend-path PATH $openmpiroot/bin/

--- a/mpi/openmpi/1.10.4/sheffield/sharc/install_openMPI_1.10.4_gcc_6_2.sh
+++ b/mpi/openmpi/1.10.4/sheffield/sharc/install_openMPI_1.10.4_gcc_6_2.sh
@@ -72,7 +72,7 @@ make install
 
 pushd ${prefix}
 wget https://github.com/open-mpi/ompi/archive/v${short_version}.zip
-unzip v${short_version}.x.zip 
-mv ompi-${short_version}.x/examples .
-rm -r ompi-${short_version}.x v${short_version}.x.zip
+unzip v${short_version}.zip 
+mv ompi-${short_version}/examples .
+rm -r ompi-${short_version}.x v${short_version}.zip
 popd

--- a/mpi/openmpi/1.10.4/sheffield/sharc/install_openMPI_1.10.4_gcc_6_2.sh
+++ b/mpi/openmpi/1.10.4/sheffield/sharc/install_openMPI_1.10.4_gcc_6_2.sh
@@ -29,31 +29,24 @@ trap handle_error ERR
 module load dev/gcc/6.2
 
 ############################## Variable Setup ################################
-version=1.10.4
+short_version=1.10
+version=${short_version}.4
 build_dir="/scratch/${USER}/openmpi_${version}"
 prefix="/usr/local/packages/mpi/openmpi/${version}/gcc-6.2"
 
-
 filename="openmpi-${version}.tar.gz"
-baseurl="http://www.open-mpi.org/software/ompi/v1.10/downloads/"
+baseurl="http://www.open-mpi.org/software/ompi/v${short_version}/downloads/"
 
-##############################################################################
-# This should not need modifying
-##############################################################################
-
-# Create the build dir
+##################### Create build and install dir ###########################
 
 [[ -d $build_dir ]] || mkdir -p $build_dir
 cd $build_dir
 
-# Create the install directory and set permissions
-#if [[ ! -d $prefix ]]; then
 mkdir -p $prefix
 chown ${USER}:app-admins $prefix
 chmod 2775 $prefix
-#fi 
 
-# Download the source
+######################### Download source ###################################
 if [[ -e $filename ]]; then
     echo "Install tarball exists. Download not required."                         
 else                                                                            
@@ -62,9 +55,7 @@ else
 fi
 
 ##############################################################################
-
-##############################################################################
-# Installation (Write the install script here)
+# Build and install
 ##############################################################################
 
 tar -xzf openmpi-${version}.tar.gz
@@ -74,3 +65,14 @@ cd openmpi-${version}
 make -j16
 make check
 make install
+
+##############################################################################
+# Download and install examples
+##############################################################################
+
+pushd ${prefix}
+wget https://github.com/open-mpi/ompi/archive/v${short_version}.zip
+unzip v${short_version}.x.zip 
+mv ompi-${short_version}.x/examples .
+rm -r ompi-${short_version}.x v${short_version}.x.zip
+popd

--- a/mpi/openmpi/2.0.1/sheffield/sharc/gcc-6.2
+++ b/mpi/openmpi/2.0.1/sheffield/sharc/gcc-6.2
@@ -23,7 +23,7 @@ module-whatis   "loads the necessary `openmpi-$openmpiversion' library paths"
 #setenv OMPI_MCA_btl_tcp_if_include eth0
 #setenv OMPI_MCA_btl tcp,self
 
-module load dev/$compiler/$compiler_version
+module load dev/$compiler/$compilerversion
 
 setenv MPI_HOME $openmpiroot
 

--- a/mpi/openmpi/2.0.1/sheffield/sharc/gcc-6.2
+++ b/mpi/openmpi/2.0.1/sheffield/sharc/gcc-6.2
@@ -23,6 +23,8 @@ module-whatis   "loads the necessary `openmpi-$openmpiversion' library paths"
 #setenv OMPI_MCA_btl_tcp_if_include eth0
 #setenv OMPI_MCA_btl tcp,self
 
+module load dev/$compiler/$compiler_version
+
 setenv MPI_HOME $openmpiroot
 
 prepend-path PATH $openmpiroot/bin/

--- a/mpi/openmpi/2.0.1/sheffield/sharc/install_openMPI_2.0.1_gcc_6.2.sh
+++ b/mpi/openmpi/2.0.1/sheffield/sharc/install_openMPI_2.0.1_gcc_6.2.sh
@@ -29,32 +29,24 @@ trap handle_error ERR
 module load dev/gcc/6.2
 
 ############################## Variable Setup ################################
-version=2.0.1
+short_version=2.0
+version=${short_version}.1
 build_dir="/scratch/${USER}/openmpi_${version}"
 prefix="/usr/local/packages/mpi/openmpi/${version}/gcc-6.2"
 
-
 filename="openmpi-${version}.tar.gz"
-#baseurl="http://www.open-mpi.org/software/ompi/v1.10/downloads/"
-baseurl="http://www.open-mpi.org/software/ompi/v2.0/downloads/"
+baseurl="http://www.open-mpi.org/software/ompi/v${short_version}/downloads/"
 
-##############################################################################
-# This should not need modifying
-##############################################################################
-
-# Create the build dir
+##################### Create build and install dir ###########################
 
 [[ -d $build_dir ]] || mkdir -p $build_dir
 cd $build_dir
 
-# Create the install directory and set permissions
-#if [[ ! -d $prefix ]]; then
 mkdir -p $prefix
 chown ${USER}:app-admins $prefix
 chmod 2775 $prefix
-#fi 
 
-# Download the source
+######################### Download source ###################################
 if [[ -e $filename ]]; then
     echo "Install tarball exists. Download not required."                         
 else                                                                            
@@ -63,9 +55,7 @@ else
 fi
 
 ##############################################################################
-
-##############################################################################
-# Installation (Write the install script here)
+# Build and install
 ##############################################################################
 
 tar -xzf openmpi-${version}.tar.gz
@@ -75,3 +65,14 @@ cd openmpi-${version}
 make -j16
 make check
 make install
+
+##############################################################################
+# Download and install examples
+##############################################################################
+
+pushd ${prefix}
+wget https://github.com/open-mpi/ompi/archive/v${short_version}.x.zip
+unzip v${short_version}.x.zip 
+mv ompi-${short_version}.x/examples .
+rm -r ompi-${short_version}.x v${short_version}.x.zip
+popd


### PR DESCRIPTION
- Ensure OpenMPI modulefiles load the version of GCC they were built with (v6.2.0)
- Ensure OpenMPI install scripts download OpenMPI examples
